### PR TITLE
fix: Correct static asset paths in index.html to resolve 404 errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PopChoice - Discover Your Perfect Movie</title>
-    <link rel="stylesheet" href="/public/css/style.css">
+    <link rel="stylesheet" href="/css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -282,6 +282,6 @@
     </div>
 
     <!-- Load JavaScript files -->
-    <script defer src="/public/js/main.js"></script>
+    <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This pull request addresses a critical issue where the deployed application on Render was loading without any CSS styling or JavaScript functionality due to incorrect asset paths in `index.html`.

## 🐛 The Problem

The deployed application was serving the main `index.html` file, but all linked assets (CSS and JS) were resulting in 404 (Not Found) errors.

This was caused by including an incorrect `/public` prefix in the `href` and `src` attributes. The `express.static('public')` middleware already maps the `public` directory to the server's root (`/`), so the extra prefix was causing Express to look for files in a non-existent path (e.g., `public/public/css/style.css`).

## ✅ The Solution

This PR corrects the file paths within `index.html` by removing the redundant `/public` prefix.

-   **CSS Path:**
    -   **Before:** `<link rel="stylesheet" href="/public/css/style.css">`
    -   **After:** `<link rel="stylesheet" href="/css/style.css">`
-   **JavaScript Path:**
    -   **Before:** `<script src="/public/js/main.js"></script>`
    -   **After:** `<script src="/js/main.js"></script>`

With this change, the browser will now correctly request `/css/style.css` and `/js/main.js`, and the Express server will successfully locate and serve them from the `public` directory. This resolves all 404 errors and ensures the application renders with its intended design and interactivity.